### PR TITLE
docs: fix typos deamon, writen, informations

### DIFF
--- a/bin/ncdns/README.md
+++ b/bin/ncdns/README.md
@@ -2,7 +2,7 @@
 
 The official nanocl controller dns build on top of dnsmasq.
 
-See [nanocl](https://github.com/next-hat/nanocl) for more informations.
+See [nanocl](https://github.com/next-hat/nanocl) for more information.
 
 ## Overview
 

--- a/crates/nanocld_client/readme.md
+++ b/crates/nanocld_client/readme.md
@@ -2,5 +2,5 @@
 
 ## Overview
 
-The nanocl deamon api client library writen in Rust powered by ntex ! </br>
+The nanocl daemon api client library written in Rust powered by ntex ! </br>
 Give you a set a function to communication to the nanocl daemon with ease.


### PR DESCRIPTION
Three typo fixes:

- `crates/nanocld_client/readme.md:5` — "The nanocl deamon api client library writen in Rust" → "daemon" and "written"
- `bin/ncdns/README.md:5` — "See nanocl for more informations" → "information" (uncountable in English)

Docs only.
